### PR TITLE
공통 response 구현

### DIFF
--- a/src/main/java/nunu/orderCount/debug/controller/TestController.java
+++ b/src/main/java/nunu/orderCount/debug/controller/TestController.java
@@ -4,12 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
+import nunu.orderCount.global.response.Response;
+import nunu.orderCount.global.response.ResponseCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Tag(name = "test api", description = "debug용 api 모음")
 @RestController
 @RequestMapping("/test")
@@ -20,7 +23,34 @@ public class TestController {
             @ApiResponse(responseCode = "200", description = "성공")
     })
     @GetMapping("/swagger")
-    public ResponseEntity<String> swaggerTest(){
-        return ResponseEntity.ok("ok");
+    public ResponseEntity<Response> swaggerTest(){
+        return Response.SUCCESS(ResponseCode.SUCCESS, "data");
     }
+
+    @GetMapping("/response/success")
+    public ResponseEntity<Response> responseSuccessTest(){
+        log.info("test");
+        return Response.SUCCESS(ResponseCode.SUCCESS, "data");
+    }
+    @GetMapping("/response/success/message")
+    public ResponseEntity<Response> responseSuccessMessageTest(){
+        log.info("test");
+        return Response.SUCCESS(ResponseCode.SUCCESS, "message", "data");
+    }
+    @GetMapping("/response/success/void")
+    public ResponseEntity<Response> responseSuccessVoidTest(){
+        log.info("test");
+        return Response.SUCCESS();
+    }
+    @GetMapping("/response/failure")
+    public ResponseEntity<Response> responseFailureVoidTest(){
+        log.info("test");
+        return Response.FAILURE(ResponseCode.FAILURE);
+    }
+    @GetMapping("/response/failure/message")
+    public ResponseEntity<Response> responseFailureTest(){
+        log.info("test");
+        return Response.FAILURE(ResponseCode.FAILURE, "message");
+    }
+
 }

--- a/src/main/java/nunu/orderCount/global/response/Response.java
+++ b/src/main/java/nunu/orderCount/global/response/Response.java
@@ -1,0 +1,70 @@
+package nunu.orderCount.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class Response<T> {
+    private ResponseStatus status;
+    private String code;
+    private String message;
+    private T data;
+    private LocalDateTime timestamp;
+
+    @Builder
+    public Response(ResponseStatus status, String code, String message, T data) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public static <T>ResponseEntity<Response> SUCCESS(ResponseCode code, T data){
+        return new ResponseEntity( Response.builder()
+                .status(ResponseStatus.SUCCESS)
+                .code(code.getCode())
+                .message(code.getMessage())
+                .data(data)
+                .build(), HttpStatus.OK);
+    }
+    public static <T>ResponseEntity<Response> SUCCESS(ResponseCode code, String message, T data){
+        return new ResponseEntity( Response.builder()
+                .status(ResponseStatus.SUCCESS)
+                .code(code.getCode())
+                .message(message)
+                .data(data)
+                .build(), HttpStatus.OK);
+    }
+    public static <T>ResponseEntity<Response> SUCCESS(){
+        return new ResponseEntity( Response.builder()
+                .status(ResponseStatus.SUCCESS)
+                .code("S200")
+                .message("ok")
+                .data(null)
+                .build(), HttpStatus.OK);
+    }
+
+    public static <T>ResponseEntity<Response> FAILURE(ResponseCode code){
+        return new ResponseEntity( Response.builder()
+                .status(ResponseStatus.FAILURE)
+                .code(code.getCode())
+                .message(code.getMessage())
+                .data(null)
+                .build(), HttpStatus.OK);
+    }
+    public static <T>ResponseEntity<Response> FAILURE(ResponseCode code, String message){
+        return new ResponseEntity( Response.builder()
+                .status(ResponseStatus.FAILURE)
+                .code(code.getCode())
+                .message(message)
+                .data(null)
+                .build(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/nunu/orderCount/global/response/ResponseCode.java
+++ b/src/main/java/nunu/orderCount/global/response/ResponseCode.java
@@ -1,0 +1,23 @@
+package nunu.orderCount.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode {
+    /**
+     * Success Code
+     * 200 : 요청 성공
+     * 201 : 요청으로 인해 새로운 리소스 생성
+     * 204 : 요청에 성공했으나 데이터는 없음
+     */
+
+    SUCCESS("S200", "요청이 완료 되었습니다."),
+    CREATED("S201", "생성이 완료되었습니다."),
+    NO_CONTENT("S204", "요청에 대한 정보가 없습니다."),
+    FAILURE("F200", "에러는 아니지만 실패했습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/nunu/orderCount/global/response/ResponseStatus.java
+++ b/src/main/java/nunu/orderCount/global/response/ResponseStatus.java
@@ -1,0 +1,5 @@
+package nunu.orderCount.global.response;
+
+public enum ResponseStatus {
+    SUCCESS, FAILURE
+}


### PR DESCRIPTION
성공과 실패 응답을 공통된 포멧으로 제공하도록 구현했습니다.
```
{
    "status": "FAILURE",
    "code": "F200",
    "message": "에러는 아니지만 실패했습니다.",
    "data": null,
    "timestamp": "2023-06-25T14:59:52.7088744"
}
```