### PR TITLE
주문 업데이트 기능 및 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.projectlombok:lombok:1.18.22'
     testImplementation 'org.projectlombok:lombok:1.18.22'
 
     //lombok

--- a/src/main/java/nunu/orderCount/domain/member/controller/MemberController.java
+++ b/src/main/java/nunu/orderCount/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
 
     @Operation(summary = "join API", description = "email과 password로 회원가입 진행")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원가입 성공")
+            @ApiResponse(responseCode = "S200", description = "회원가입 성공")
     })
     @PostMapping("/join")
     public ResponseEntity<Response> join(@RequestBody @Valid RequestJoinDto dto) {

--- a/src/main/java/nunu/orderCount/domain/member/model/Member.java
+++ b/src/main/java/nunu/orderCount/domain/member/model/Member.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 import nunu.orderCount.global.common.BaseEntity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -18,9 +20,13 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
+    @NotNull
     private String email; //id
+    @NotNull
     private String password;
+    @NotNull
     private Role role;
+    @NotNull
     private boolean isLocked;
     //todo: refresh, zigzag token 은 redis 로 관리할 예정
     //todo: platform 추가
@@ -33,4 +39,23 @@ public class Member extends BaseEntity {
         this.role = Role.OWNER;
     }
     //todo: role 관련해서 수정할 것.
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Member member = (Member) o;
+
+        if (!memberId.equals(member.memberId)) return false;
+        return email.equals(member.email);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = memberId.hashCode();
+        result = 31 * result + email.hashCode();
+        return result;
+    }
 }

--- a/src/main/java/nunu/orderCount/domain/member/model/MemberInfo.java
+++ b/src/main/java/nunu/orderCount/domain/member/model/MemberInfo.java
@@ -1,0 +1,11 @@
+package nunu.orderCount.domain.member.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberInfo {
+    private final Member member;
+    private final String zigzagToken;
+}

--- a/src/main/java/nunu/orderCount/domain/member/model/dto/request/RequestJoinDto.java
+++ b/src/main/java/nunu/orderCount/domain/member/model/dto/request/RequestJoinDto.java
@@ -17,6 +17,7 @@ public class RequestJoinDto {
 
     @Email(message = "올바르지 않은 이메일 형식입니다")
     @Schema(description = "이메일", example = "email@naver.com")
+    @NotEmpty
     private String email;
 
     @Schema(description = "비밀번호", example = "password1234")

--- a/src/main/java/nunu/orderCount/domain/member/model/dto/request/RequestLoginDto.java
+++ b/src/main/java/nunu/orderCount/domain/member/model/dto/request/RequestLoginDto.java
@@ -16,6 +16,7 @@ import javax.validation.constraints.NotEmpty;
 public class RequestLoginDto {
     @Email(message = "올바르지 않은 이메일 형식입니다")
     @Schema(description = "이메일", example = "email@naver.com")
+    @NotEmpty
     private String email;
 
     @Schema(description = "비밀번호", example = "password1234")

--- a/src/main/java/nunu/orderCount/domain/member/service/MemberService.java
+++ b/src/main/java/nunu/orderCount/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nunu.orderCount.domain.member.exception.*;
 import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.model.MemberInfo;
 import nunu.orderCount.domain.member.model.dto.request.RequestJoinDto;
 import nunu.orderCount.domain.member.model.dto.request.RequestLoginDto;
 import nunu.orderCount.domain.member.model.dto.request.RequestRefreshZigzagTokenDto;
@@ -125,5 +126,17 @@ public class MemberService {
         redisUtil.setData(REDIS_ZIGZAG_TOKEN + member.getMemberId(), zigzagToken, ZIGZAG_EXPIRE_TIME);
 
         return new ResponseRefreshZigzagToken("done");
+    }
+
+
+    public MemberInfo createMemberInfo(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NotExistMemberException("존재하지 않는 회원 id입니다."));
+        String zigzagToken = redisUtil.getData(REDIS_ZIGZAG_TOKEN + member.getMemberId());
+
+        //todo: null일 경우 validate
+        if (zigzagToken.equals(null)) {
+        }
+
+        return new MemberInfo(member, zigzagToken);
     }
 }

--- a/src/main/java/nunu/orderCount/domain/option/model/Option.java
+++ b/src/main/java/nunu/orderCount/domain/option/model/Option.java
@@ -7,33 +7,57 @@ import lombok.NoArgsConstructor;
 import nunu.orderCount.domain.product.model.Product;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 @Entity
 @Getter
-@Table(name = "option")
+@Table(name = "options")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Option {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long optionId;
 
+    @NotNull
     private String name;
+    @NotNull
     private Integer inventoryQuantity;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Product product;
-
-    @Builder
-    public Option(String name, Integer inventoryQuantity, Product product) {
-        this.name = name;
-        this.inventoryQuantity = inventoryQuantity;
-        this.product = product;
-    }
 
     @Builder
     public Option(String name, Product product) {
         this.name = name;
         this.inventoryQuantity = 0;
+        this.product = product;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Option option = (Option) o;
+
+        if (!Objects.equals(optionId, option.optionId)) return false;
+        if (!Objects.equals(name, option.name)) return false;
+        if (!Objects.equals(inventoryQuantity, option.inventoryQuantity))
+            return false;
+        return Objects.equals(product, option.product);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = optionId != null ? optionId.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (inventoryQuantity != null ? inventoryQuantity.hashCode() : 0);
+        result = 31 * result + (product != null ? product.hashCode() : 0);
+        return result;
+    }
+
+    public void setProduct(Product product) {
         this.product = product;
     }
 }

--- a/src/main/java/nunu/orderCount/domain/option/model/OptionDtoInfo.java
+++ b/src/main/java/nunu/orderCount/domain/option/model/OptionDtoInfo.java
@@ -1,0 +1,16 @@
+package nunu.orderCount.domain.option.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class OptionDtoInfo {
+    private String optionName;
+    private String zigzagProductId;
+}

--- a/src/main/java/nunu/orderCount/domain/option/model/dto/request/RequestCreateOptionsDto.java
+++ b/src/main/java/nunu/orderCount/domain/option/model/dto/request/RequestCreateOptionsDto.java
@@ -1,0 +1,17 @@
+package nunu.orderCount.domain.option.model.dto.request;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.option.model.OptionDtoInfo;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RequestCreateOptionsDto {
+    private MemberInfo memberInfo;
+    private List<OptionDtoInfo> optionDtoInfos;
+}

--- a/src/main/java/nunu/orderCount/domain/option/repository/OptionRepository.java
+++ b/src/main/java/nunu/orderCount/domain/option/repository/OptionRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface OptionRepository extends JpaRepository<Option, Long> {
     public Optional<Option> findByProductAndName(Product product, String name);
+
+    public Boolean existsByProductAndName(Product product, String name);
 }

--- a/src/main/java/nunu/orderCount/domain/option/service/OptionService.java
+++ b/src/main/java/nunu/orderCount/domain/option/service/OptionService.java
@@ -1,0 +1,51 @@
+package nunu.orderCount.domain.option.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.option.model.Option;
+import nunu.orderCount.domain.option.model.OptionDtoInfo;
+import nunu.orderCount.domain.option.model.dto.request.RequestCreateOptionsDto;
+import nunu.orderCount.domain.option.repository.OptionRepository;
+import nunu.orderCount.domain.product.model.Product;
+import nunu.orderCount.domain.product.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OptionService {
+    private final OptionRepository optionRepository;
+    private final ProductRepository productRepository;
+
+    public void createOptions(RequestCreateOptionsDto dto) {
+        List<Option> options = extractUnsavedOptions(dto.getOptionDtoInfos(), dto.getMemberInfo().getMember());
+        optionRepository.saveAll(options);
+    }
+
+    private List<Option> extractUnsavedOptions(List<OptionDtoInfo> optionDtoInfos, Member member) {
+        return optionDtoInfos.stream()
+                .distinct()
+                .filter(optionInfo -> {
+                    Optional<Product> product = productRepository.findByZigzagProductIdAndMember(
+                            optionInfo.getZigzagProductId(), member);
+                    if (product.isPresent()) {
+                        return !optionRepository.existsByProductAndName(product.get(), optionInfo.getOptionName());
+                    } else {
+                        return false;
+                    }
+                })
+                .map(optionDtoInfo -> {
+                    Product product = productRepository.findByZigzagProductIdAndMember(
+                            optionDtoInfo.getZigzagProductId(), member).get();
+                    return Option.builder()
+                            .name(optionDtoInfo.getOptionName())
+                            .product(product)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/nunu/orderCount/domain/order/controller/OrderController.java
+++ b/src/main/java/nunu/orderCount/domain/order/controller/OrderController.java
@@ -1,10 +1,32 @@
 package nunu.orderCount.domain.order.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.member.service.MemberService;
+import nunu.orderCount.domain.option.model.OptionDtoInfo;
+import nunu.orderCount.domain.option.model.dto.request.RequestCreateOptionsDto;
+import nunu.orderCount.domain.option.service.OptionService;
+import nunu.orderCount.domain.order.model.OrderDtoInfo;
+import nunu.orderCount.domain.order.model.dto.request.RequestOrderUpdateDto;
+import nunu.orderCount.domain.order.model.dto.response.ResponseOrderUpdateDto;
+import nunu.orderCount.domain.order.service.OrderServiceImpl;
+import nunu.orderCount.domain.product.model.ProductDtoInfo;
+import nunu.orderCount.domain.product.model.dto.request.RequestUpdateProductDto;
+import nunu.orderCount.domain.product.service.ProductServiceImpl;
+import nunu.orderCount.global.error.ErrorResponse;
+import nunu.orderCount.global.response.Response;
+import nunu.orderCount.infra.zigzag.model.dto.response.ResponseZigzagOrderDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @Tag(name = "Order 관련 API")
@@ -12,4 +34,61 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class OrderController {
+
+    private final OrderServiceImpl orderService;
+    private final MemberService memberService;
+    private final ProductServiceImpl productService;
+    private final OptionService optionService;
+
+    //todo: swagger 위한 error 정리
+    @Operation(summary = "주문 업데이트 API", description = "회원 id로 주문 업데이트 진행")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "S200", description = "주문 업데이트 성공"),
+            @ApiResponse(responseCode = "200(data)", description = "주문 업데이트 성공", content = @Content(schema = @Schema(implementation = ResponseOrderUpdateDto.class))),
+            @ApiResponse(responseCode = "O001", description = "주문 업데이트 실패 - zigzag token null", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "O002", description = "주문 업데이트 실패 - zigzag 요청 실패, zigzag token refresh 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "M004", description = "주문 업데이트 실패 - 회원 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{id}")
+    public ResponseEntity<Response> updateZigzagOrder(@PathVariable("id") Long id) {
+        MemberInfo memberInfo = memberService.createMemberInfo(id);
+        List<ResponseZigzagOrderDto> ordersFromZigzag = orderService.getOrdersFromZigzag(memberInfo);
+        updateProduct(ordersFromZigzag, memberInfo);
+        updateOption(ordersFromZigzag, memberInfo);
+        ResponseOrderUpdateDto response = updateOrder(ordersFromZigzag, memberInfo);
+        return Response.SUCCESS("주문 업데이트가 완료되었습니다.", response);
+    }
+
+    private void updateProduct(List<ResponseZigzagOrderDto> ordersFromZigzag, MemberInfo memberInfo){
+        List<ProductDtoInfo> productDtoInfos = ordersFromZigzag.stream()
+                .map(o -> {
+                    return new ProductDtoInfo(o.getProductName(), o.getProductId());
+                })
+                .distinct()
+                .collect(Collectors.toList());
+        productDtoInfos.forEach(productDtoInfo -> log.info("product: {} {}",productDtoInfo.getProductName(), productDtoInfo.getZigzagProductId()));
+
+        productService.updateProduct(new RequestUpdateProductDto(memberInfo,productDtoInfos));
+    }
+
+    private void updateOption(List<ResponseZigzagOrderDto> ordersFromZigzag, MemberInfo memberInfo){
+        List<OptionDtoInfo> optionDtoInfos = ordersFromZigzag.stream()
+                .map(o -> {
+                    return new OptionDtoInfo(o.getOption(), o.getProductId());
+                })
+                .distinct()
+                .collect(Collectors.toList());
+        optionService.createOptions(new RequestCreateOptionsDto(memberInfo, optionDtoInfos));
+    }
+    
+    private ResponseOrderUpdateDto updateOrder(List<ResponseZigzagOrderDto> ordersFromZigzag, MemberInfo memberInfo){
+        List<OrderDtoInfo> orderDtoInfos = ordersFromZigzag.stream()
+                .map(o ->
+                        new OrderDtoInfo(o.getQuantity(), o.getOrderItemNumber(), o.getOrderNumber(),
+                                o.getDatePaid(), o.getProductId(), o.getOption())
+                )
+                .distinct()
+                .collect(Collectors.toList());
+        return orderService.orderUpdate(new RequestOrderUpdateDto(memberInfo, orderDtoInfos));
+    }
 }

--- a/src/main/java/nunu/orderCount/domain/order/model/Order.java
+++ b/src/main/java/nunu/orderCount/domain/order/model/Order.java
@@ -6,32 +6,38 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nunu.orderCount.domain.member.model.Member;
 import nunu.orderCount.domain.option.model.Option;
-import nunu.orderCount.domain.product.model.Product;
 import nunu.orderCount.global.common.BaseEntity;
-import nunu.orderCount.infra.zigzag.model.dto.response.ResponseZigzagOrderDto;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 @Entity
 @Getter
-@Table(name = "order_table")
+@Table(name = "orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long orderId;
+    @NotNull
     private Long quantity; //주문 수량
+    @NotNull
     @Column(unique = true)
     private String orderItemNumber; //상품 주문 번호
-    @Column(unique = true)
+    @NotNull
     private String orderNumber; //주문 번호
+    @NotNull
     private Long datePaid; //결제 일자
+    @NotNull
     private Boolean isDone; //배송 준비 완료 유무
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @NotNull
     private Option option;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @NotNull
     private Member member;
 
     @Builder
@@ -45,18 +51,41 @@ public class Order extends BaseEntity {
         this.isDone = false;
     }
 
-    public static Order of(ResponseZigzagOrderDto dto, Member member, Option option) {
-        return Order.builder()
-                .orderItemNumber(dto.getOrderItemNumber())
-                .orderNumber(dto.getOrderNumber())
-                .option(option)
-                .member(member)
-                .quantity(dto.getQuantity())
-                .datePaid(dto.getDatePaid())
-                .build();
-    }
-
     public void setDone() {
         isDone = true;
+    }
+
+    public void setOption(Option option) {
+        this.option = option;
+    }
+
+        @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Order order = (Order) o;
+
+        if (!Objects.equals(orderId, order.orderId)) return false;
+        if (!Objects.equals(quantity, order.quantity)) return false;
+        if (!Objects.equals(orderItemNumber, order.orderItemNumber))
+            return false;
+        if (!Objects.equals(orderNumber, order.orderNumber)) return false;
+        if (!Objects.equals(datePaid, order.datePaid)) return false;
+        if (!Objects.equals(option, order.option)) return false;
+        return Objects.equals(member, order.member);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = orderId != null ? orderId.hashCode() : 0;
+//        int result = quantity != null ? quantity.hashCode() : 0;
+        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
+        result = 31 * result + (orderItemNumber != null ? orderItemNumber.hashCode() : 0);
+        result = 31 * result + (orderNumber != null ? orderNumber.hashCode() : 0);
+        result = 31 * result + (datePaid != null ? datePaid.hashCode() : 0);
+        result = 31 * result + (option != null ? option.hashCode() : 0);
+        result = 31 * result + (member != null ? member.hashCode() : 0);
+        return result;
     }
 }

--- a/src/main/java/nunu/orderCount/domain/order/model/OrderDtoInfo.java
+++ b/src/main/java/nunu/orderCount/domain/order/model/OrderDtoInfo.java
@@ -1,0 +1,27 @@
+package nunu.orderCount.domain.order.model;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class OrderDtoInfo {
+    @NotNull
+    private Long quantity; //주문 수량
+    @NotNull
+    private String orderItemNumber; //상품 주문 번호
+    @NotNull
+    private String orderNumber; //주문 번호
+    @NotNull
+    private Long datePaid; //결제 일자
+    @NotNull
+    private String productId;
+    @NotNull
+    private String optionName;
+}

--- a/src/main/java/nunu/orderCount/domain/order/model/dto/request/RequestOrderUpdateDto.java
+++ b/src/main/java/nunu/orderCount/domain/order/model/dto/request/RequestOrderUpdateDto.java
@@ -1,17 +1,27 @@
 package nunu.orderCount.domain.order.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.order.model.OrderDtoInfo;
+
 
 @Schema(name = "주문 현황 업데이트 dto", description = "주문 현황 업데이트에 필요한 정보")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class RequestOrderUpdateDto {
+    @Schema(description = "회원 정보", example = "")
+    @NotNull
+    private MemberInfo memberInfo;
 
-    @Schema(description = "회원 id", example = "1L")
-    private Long memberId;
+    @Schema(description = "주문 정보", example = "")
+    @NotNull
+    private List<OrderDtoInfo> orderDtoInfos;
 }

--- a/src/main/java/nunu/orderCount/domain/order/model/dto/response/ResponseOrderUpdateDto.java
+++ b/src/main/java/nunu/orderCount/domain/order/model/dto/response/ResponseOrderUpdateDto.java
@@ -6,6 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class ResponseOrderUpdateDto {
-    private final Long newOrderCount;
-    private final Long changeStatusOrderCount;
+    private final Integer newOrderCount;
+    private final Integer changeStatusOrderCount;
 }

--- a/src/main/java/nunu/orderCount/domain/order/repository/OrderRepository.java
+++ b/src/main/java/nunu/orderCount/domain/order/repository/OrderRepository.java
@@ -11,5 +11,6 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findTopByMemberOrderByDatePaidDesc(Member member);
 
+    Boolean existsByMemberAndOrderItemNumber(Member member, String orderItemNumber);
     List<Order> findByMemberAndIsDoneFalse(Member member);
 }

--- a/src/main/java/nunu/orderCount/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/nunu/orderCount/domain/order/service/OrderServiceImpl.java
@@ -3,13 +3,14 @@ package nunu.orderCount.domain.order.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.model.MemberInfo;
 import nunu.orderCount.domain.member.repository.MemberRepository;
 import nunu.orderCount.domain.option.model.Option;
 import nunu.orderCount.domain.option.repository.OptionRepository;
 import nunu.orderCount.domain.order.exception.InvalidZigzagTokenException;
-import nunu.orderCount.domain.order.exception.NotExistMemberException;
 import nunu.orderCount.domain.order.exception.ZigzagRequestFailException;
 import nunu.orderCount.domain.order.model.Order;
+import nunu.orderCount.domain.order.model.OrderDtoInfo;
 import nunu.orderCount.domain.order.model.dto.request.RequestOrderUpdateDto;
 import nunu.orderCount.domain.order.model.dto.response.ResponseOrderUpdateDto;
 import nunu.orderCount.domain.order.repository.OrderRepository;
@@ -25,10 +26,8 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -40,92 +39,88 @@ public class OrderServiceImpl implements OrderService{
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final OptionRepository optionRepository;
-    private final RedisUtil redisUtil;
     private final ZigzagOrderService zigzagOrderService;
-    private final ZigzagProductService zigzagProductService;
-    @Value("${spring.redis.key.zigzag-token}")
-    private String REDIS_ZIGZAG_TOKEN;
+
+    /**
+     * zigzag에서 새로운 order 정보를 받아옵니다.
+     *
+     * @return zigzag order 정보 list
+     */
+    public List<ResponseZigzagOrderDto> getOrdersFromZigzag(MemberInfo memberInfo) {
+        //zigzagOrderService 에서 order 정보 받아오기
+        Optional<Order> latestOrder = orderRepository.findTopByMemberOrderByDatePaidDesc(memberInfo.getMember());
+        Integer startDate = calStartDate(latestOrder);
+        Integer endDate = Integer.parseInt(String.valueOf(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))));
+        List<ResponseZigzagOrderDto> zigzagOrderList = zigzagOrderService.zigzagOrderListRequester(
+                memberInfo.getZigzagToken(), startDate, endDate);
+
+        if (zigzagOrderList == null) {
+            throw new InvalidZigzagTokenException();
+        }
+
+        return zigzagOrderList;
+    }
 
     @Override
     public ResponseOrderUpdateDto orderUpdate(RequestOrderUpdateDto dto) {
-        Member member = memberRepository.findById(dto.getMemberId()).orElseThrow(() -> new NotExistMemberException("존재하지 않는 회원입니다."));
-        String zigzagToken = redisUtil.getData(REDIS_ZIGZAG_TOKEN + member.getMemberId());
-        if (zigzagToken == null) {
-            throw new InvalidZigzagTokenException("zigzag token refresh가 필요합니다.");
-        }
+        //배송준비중인 order list 만들기
+        List<Order> orders = makeOrderList(dto.getOrderDtoInfos(), dto.getMemberInfo());
 
-        Optional<Order> latestOrder = orderRepository.findTopByMemberOrderByDatePaidDesc(member);
-        Integer startDate = calStartDate(latestOrder);
-        Integer endDate = Integer.parseInt(String.valueOf(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))));
+        //새로 저장할 order list 뽑기 -> orderRepository에 저장되어 있지 않은 order list
+        List<Order> newOrders = extractNewOrders(orders, dto.getMemberInfo().getMember());
 
-        List<ResponseZigzagOrderDto> zigzagOrderList = zigzagOrderService.zigzagOrderListRequester(zigzagToken, startDate, endDate);
-        if (zigzagOrderList == null) {
-            throw new ZigzagRequestFailException("zigzag 요청에 실패했습니다. zigzag token refresh가 필요합니다.");
-        }
+        //완료된 order 상태 변환
+        List<Order> doneOrders = new ArrayList<>(orderRepository.findByMemberAndIsDoneFalse(
+                dto.getMemberInfo().getMember()));
+        doneOrders.removeAll(orders);
 
-        List<String> imageRequestList = new ArrayList<>();
-        List<Product> saveProductList = new ArrayList<>();
-        List<Option> saveOptionList = new ArrayList<>();
-        List<Order> saveOrderList = new ArrayList<>();
-        for (ResponseZigzagOrderDto zigzagOrder : zigzagOrderList) {
-            Optional<Product> orderProduct = productRepository.findByZigzagProductId(zigzagOrder.getProductId());
-            Product product;
-            Option option;
-            if (orderProduct.isEmpty()) { //product(zigzag image 요청), option save
-                product = Product.builder()
-                        .member(member)
-                        .zigzagProductId(zigzagOrder.getProductId())
-                        .name(zigzagOrder.getProductName())
-                        .build();
-                option = Option.builder()
-                        .name(zigzagOrder.getOption())
-                        .product(product)
-                        .build();
-                saveProductList.add(product);
-                saveOptionList.add(option);
-                imageRequestList.add(zigzagOrder.getProductId());
-            }
-            else{
-                Optional<Option> orderOption = optionRepository.findByProductAndName(orderProduct.get(), zigzagOrder.getOption());
-                if (orderOption.isEmpty()) { //option save
-                    option = Option.builder()
-                            .name(zigzagOrder.getOption())
-                            .product(orderProduct.get())
+        doneOrders.stream().forEach(order -> {
+            order.setDone();
+        });
+
+        orderRepository.saveAll(newOrders);
+        orderRepository.saveAll(doneOrders);
+        return new ResponseOrderUpdateDto(newOrders.size(), doneOrders.size());
+    }
+
+    private List<Order> makeOrderList(List<OrderDtoInfo> orderDtoInfos, MemberInfo memberInfo){
+        return orderDtoInfos.stream()
+                .distinct()
+                .map(orderDtoInfo -> {
+                    Optional<Product> product = productRepository.findByZigzagProductIdAndMember(
+                            orderDtoInfo.getProductId(), memberInfo.getMember());
+                    if (product.isEmpty()) return null;
+                    Optional<Option> option = optionRepository.findByProductAndName(product.get(),
+                            orderDtoInfo.getOptionName());
+                    if (option.isEmpty()) return null;
+
+                    return Order.builder()
+                            .option(option.get())
+                            .datePaid(orderDtoInfo.getDatePaid())
+                            .member(memberInfo.getMember())
+                            .orderNumber(orderDtoInfo.getOrderNumber())
+                            .orderItemNumber(orderDtoInfo.getOrderItemNumber())
+                            .quantity(orderDtoInfo.getQuantity())
                             .build();
-                    saveOptionList.add(option);
-                }
-                else{
-                    option = orderOption.get();
-                }
-            }
-            Order order = Order.of(zigzagOrder, member, option);
-            saveOrderList.add(order);
-        }
-        if (!imageRequestList.isEmpty()) {
-            Map<String, String> imageUrlMap = zigzagProductService.ZigzagProductImagesUrlRequester(zigzagToken, imageRequestList);
-            saveProductList.forEach(p -> p.setImageUrl(imageUrlMap.get(p.getZigzagProductId())));
-        }
-        productRepository.saveAll(saveProductList);
-        optionRepository.saveAll(saveOptionList);
-        
-        //배송준비중 아닌(완료된) order의 isDone true로 변환
-        List<Order> doneOrderList = new ArrayList<>(orderRepository.findByMemberAndIsDoneFalse(member));
-        doneOrderList.removeAll(saveOrderList);
-        saveOrderList.removeAll(doneOrderList);
-        doneOrderList.forEach(o -> o.setDone());
-        
-        orderRepository.saveAll(saveOrderList); //새로 추가
-        orderRepository.saveAll(doneOrderList); //완료 된 것 상태변화
+                })
+                .filter(o -> o != null)
+                .collect(Collectors.toList());
+    }
 
-        return new ResponseOrderUpdateDto(saveOrderList.stream().count(), doneOrderList.stream().count());
+    private List<Order> extractNewOrders(List<Order> orders, Member member){
+        return orders.stream()
+                .filter(order -> !orderRepository.existsByMemberAndOrderItemNumber(member, order.getOrderItemNumber()))
+                .collect(Collectors.toList());
     }
 
     private Integer calStartDate(Optional<Order> latestOrder) {
         if(latestOrder.isPresent()) {
+            log.info("last order is present");
             return Integer.parseInt(String.valueOf(latestOrder.get().getDatePaid()));
         }
         else{
-            return Integer.parseInt(String.valueOf(LocalDate.now().minusMonths(2L)));
+            log.info("last order is null");
+            return Integer.parseInt(String.valueOf(LocalDate.now().minusMonths(1L).format(DateTimeFormatter.ofPattern("yyyyMMdd"))));
         }
     }
 }

--- a/src/main/java/nunu/orderCount/domain/product/model/Product.java
+++ b/src/main/java/nunu/orderCount/domain/product/model/Product.java
@@ -6,8 +6,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nunu.orderCount.domain.member.model.Member;
 import nunu.orderCount.global.common.BaseEntity;
+import nunu.orderCount.infra.zigzag.model.dto.response.ResponseZigzagOrderDto;
+import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -17,12 +21,15 @@ public class Product extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long productId;
+    @NotNull
     private String name;
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
+    @NotNull
     @Column(unique = true)
     private String zigzagProductId;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @NotNull
     private Member member;
 
     @Builder
@@ -33,6 +40,7 @@ public class Product extends BaseEntity {
         this.member = member;
     }
 
+    //todo: setImageUrl 과 함께 삭제 예정
     @Builder
     public Product(String name, String zigzagProductId, Member member) {
         this.name = name;
@@ -42,6 +50,30 @@ public class Product extends BaseEntity {
 
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Product product = (Product) o;
+
+        if (!Objects.equals(productId, product.productId)) return false;
+        if (!name.equals(product.name)) return false;
+        if (!Objects.equals(imageUrl, product.imageUrl)) return false;
+        if (!zigzagProductId.equals(product.zigzagProductId)) return false;
+        return member.equals(product.member);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = productId != null ? productId.hashCode() : 0;
+        result = 31 * result + name.hashCode();
+        result = 31 * result + (imageUrl != null ? imageUrl.hashCode() : 0);
+        result = 31 * result + zigzagProductId.hashCode();
+        result = 31 * result + member.hashCode();
+        return result;
     }
 }
 

--- a/src/main/java/nunu/orderCount/domain/product/model/ProductDtoInfo.java
+++ b/src/main/java/nunu/orderCount/domain/product/model/ProductDtoInfo.java
@@ -1,0 +1,17 @@
+package nunu.orderCount.domain.product.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ProductDtoInfo {
+    private String productName;
+    private String zigzagProductId;
+}
+

--- a/src/main/java/nunu/orderCount/domain/product/model/dto/request/RequestUpdateProductDto.java
+++ b/src/main/java/nunu/orderCount/domain/product/model/dto/request/RequestUpdateProductDto.java
@@ -1,0 +1,21 @@
+package nunu.orderCount.domain.product.model.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.product.model.ProductDtoInfo;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RequestUpdateProductDto {
+    @NotNull
+    private MemberInfo memberInfo;
+
+    @NotNull
+    private List<ProductDtoInfo> productInfos;
+}

--- a/src/main/java/nunu/orderCount/domain/product/repository/ProductRepository.java
+++ b/src/main/java/nunu/orderCount/domain/product/repository/ProductRepository.java
@@ -1,12 +1,17 @@
 package nunu.orderCount.domain.product.repository;
 
+import nunu.orderCount.domain.member.model.Member;
 import nunu.orderCount.domain.product.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
+import javax.persistence.LockModeType;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Boolean existsByZigzagProductId(String zigzagProductId);
+    Boolean existsByZigzagProductIdAndMember(String zigzagProductId, Member member);
 
     Optional<Product> findByZigzagProductId(String zigzagProductId);
+    Optional<Product> findByZigzagProductIdAndMember(String zigzagProductId, Member member);
 }

--- a/src/main/java/nunu/orderCount/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/nunu/orderCount/domain/product/service/ProductServiceImpl.java
@@ -1,7 +1,16 @@
 package nunu.orderCount.domain.product.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.product.model.Product;
+import nunu.orderCount.domain.product.model.ProductDtoInfo;
+import nunu.orderCount.domain.product.model.dto.request.RequestUpdateProductDto;
+import nunu.orderCount.domain.product.repository.ProductRepository;
+import nunu.orderCount.infra.zigzag.service.ZigzagProductService;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -12,5 +21,45 @@ import javax.transaction.Transactional;
 @RequiredArgsConstructor
 public class ProductServiceImpl implements ProductService{
 
-    //상품
+    private final ProductRepository productRepository;
+    private final ZigzagProductService zigzagProductService;
+
+    //상품 update
+    public void updateProduct(RequestUpdateProductDto dto) {
+        //1. 저장되지 않은 product 찾기
+        List<ProductDtoInfo> productDtoInfos = dto.getProductInfos().stream()
+                .distinct()
+                .filter(productInfo -> !productRepository.existsByZigzagProductIdAndMember(
+                        productInfo.getZigzagProductId(), dto.getMemberInfo().getMember()))
+                .collect(Collectors.toList());
+
+        List<String> zigzagProductIds = productDtoInfos.stream().map(ProductDtoInfo::getZigzagProductId)
+                .collect(Collectors.toList());
+
+        //2. zigzag에서 image url 찾기
+        Map<String, String> productImageUrls = zigzagProductService.ZigzagProductImagesUrlRequester(
+                dto.getMemberInfo().getZigzagToken(), zigzagProductIds);
+
+        //3. product list 만들기
+        List<Product> products = createProducts(productImageUrls, productDtoInfos, dto.getMemberInfo().getMember());
+
+        productRepository.saveAll(products);
+    }
+
+    private List<Product> createProducts(Map<String, String> productImageUrls, List<ProductDtoInfo> productDtoInfos, Member member){
+        List<Product> products = productDtoInfos.stream().map(productInfo -> {
+                    String imageUrl = "";
+                    if (productImageUrls.get(productInfo.getZigzagProductId()) != null) {
+                        imageUrl = productImageUrls.get(productInfo.getZigzagProductId());
+                    }
+                    return Product.builder()
+                            .zigzagProductId(productInfo.getZigzagProductId())
+                            .member(member)
+                            .name(productInfo.getProductName())
+                            .imageUrl(imageUrl)
+                            .build();
+                })
+                .collect(Collectors.toList());
+        return products;
+    }
 }

--- a/src/main/java/nunu/orderCount/global/config/WebClientConfig.java
+++ b/src/main/java/nunu/orderCount/global/config/WebClientConfig.java
@@ -1,14 +1,19 @@
 package nunu.orderCount.global.config;
 
 import io.netty.channel.ChannelOption;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
 
+@Slf4j
 @Configuration
 public class WebClientConfig {
 
@@ -21,6 +26,18 @@ public class WebClientConfig {
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1*1024*1024)) //1M 설정, 기본 256KB
                 .defaultHeader("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36")
+//                .filter(
+//                        ExchangeFilterFunction.ofRequestProcessor(
+//                                clientRequest -> {
+//                                    log.info("------REQUEST--------");
+//                                    log.info("Request: {} {}", clientRequest.method(), clientRequest.url());
+//                                    clientRequest.headers().forEach(
+//                                            (name, values) -> values.forEach(value -> log.info("{} : {}", name, value))
+//                                    );
+//                                    return Mono.just(clientRequest);
+//                                }
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/nunu/orderCount/global/error/ExceptionHandlerFilter.java
+++ b/src/main/java/nunu/orderCount/global/error/ExceptionHandlerFilter.java
@@ -33,11 +33,13 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     private void setErrorResponse(HttpServletResponse response, BusinessException e) {
         ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
         log.error("error occurred in filter: {}", errorResponse.getTrackingId());
+        log.error("error message: {}", e.getMessage());
         writeResponse(response, errorResponse, e.getErrorCode().getStatus());
     }
     private void setUnexpectedErrorResponse(HttpServletResponse response, Exception e) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
         log.error("unexpected error occurred in filter: {}", errorResponse.getTrackingId());
+        log.error("error message: {}", e.getMessage() + "\n" + response.toString());
         writeResponse(response, errorResponse, 500);
     }
     private void writeResponse(HttpServletResponse response, ErrorResponse errorResponse, int status) {

--- a/src/main/java/nunu/orderCount/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/nunu/orderCount/global/error/GlobalExceptionHandler.java
@@ -12,20 +12,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    //todo: BusinessException 찍지 말고 발생 class 받아서 명확하게 표시해줄 것
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> businessExceptionHandler(BusinessException e){
 //        log.info("error: {}", e.getErrorCode().getMessage());
-        log.error("businessException: {}", e.getMessage());
+        log.error("businessException: {}, {}", e.getErrorCode().getMessage(), e.getMessage());
         return ErrorResponse.of(e.getErrorCode(), e.getMessage());
     }
 
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> accessDeniedExceptionHandler(AccessDeniedException e) {
+        log.error("AccessDeniedException: {}", e.getMessage());
         return businessExceptionHandler(new BusinessException(ErrorCode.PERMISSION_DENIED));
     }
 
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> illegalArgumentExceptionHandler(IllegalArgumentException e) {
+        log.error("IllegalArgumentException: {}", e.getMessage());
         return businessExceptionHandler(new BusinessException(ErrorCode.PERMISSION_DENIED));
         //todo: 수정 필요
     }

--- a/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/OrderVariables.java
+++ b/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/OrderVariables.java
@@ -1,0 +1,29 @@
+package nunu.orderCount.infra.zigzag.model.dto.request;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+public class OrderVariables {
+    private final List<String> status_list;
+    private final boolean only_late_shipment;
+    private final boolean only_withdrawn_cancel_request;
+    private final Integer page;
+    private final Integer items_per_page;
+    private final String order_by;
+    private final Integer date_marked_awaiting_shipment_ymd_gte;
+    private final Integer date_marked_awaiting_shipment_ymd_lte;
+
+    public OrderVariables(Integer date_marked_awaiting_shipment_ymd_gte, Integer date_marked_awaiting_shipment_ymd_lte) {
+        this.status_list = Arrays.asList("AWAITING_SHIPMENT");
+        this.only_late_shipment = false;
+        this.only_withdrawn_cancel_request = false;
+        this.page = 1;
+        this.items_per_page = 100;
+        this.order_by = "DATE_PAID_DESC";
+        this.date_marked_awaiting_shipment_ymd_gte = date_marked_awaiting_shipment_ymd_gte;
+        this.date_marked_awaiting_shipment_ymd_lte = date_marked_awaiting_shipment_ymd_lte;
+    }
+}

--- a/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/RequestZigzagOrderDto.java
+++ b/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/RequestZigzagOrderDto.java
@@ -15,25 +15,3 @@ public class RequestZigzagOrderDto {
     }
 }
 
-@Getter
-class OrderVariables {
-    private final List<String> status_list;
-    private final boolean only_late_shipment;
-    private final boolean only_withdrawn_cancel_request;
-    private final Integer page;
-    private final Integer items_per_page;
-    private final String order_by;
-    private final Integer date_marked_awaiting_shipment_ymd_gte;
-    private final Integer date_marked_awaiting_shipment_ymd_lte;
-
-    public OrderVariables(Integer date_marked_awaiting_shipment_ymd_gte, Integer date_marked_awaiting_shipment_ymd_lte) {
-        this.status_list = Arrays.asList("AWAITING_SHIPMENT");
-        this.only_late_shipment = false;
-        this.only_withdrawn_cancel_request = false;
-        this.page = 1;
-        this.items_per_page = 100;
-        this.order_by = "DATE_PAID_DESC";
-        this.date_marked_awaiting_shipment_ymd_gte = date_marked_awaiting_shipment_ymd_gte;
-        this.date_marked_awaiting_shipment_ymd_lte = date_marked_awaiting_shipment_ymd_lte;
-    }
-}

--- a/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/RequestZigzagProductInfoDto.java
+++ b/src/main/java/nunu/orderCount/infra/zigzag/model/dto/request/RequestZigzagProductInfoDto.java
@@ -27,43 +27,10 @@ class ProductVariables {
 
 @Getter
 class ProductInput{
-    private final String display_status;
-    private final String product_type;
-    private final String entry_type;
-    private final String suspend_status;
-    private final String quality_status;
-    private final Long skip_count;
-    private final Long limit_count;
-    private final String product_code_list;
-    private final String name;
+
     private final List<String> id_list;
-    private final String external_product_ids;
-    private final String brand_id_list;
-    private final String preorder;
-    private final String trait_type_list;
-    private final String penalty_status_list;
-    private final List<String> sales_status_list;
-    private final Long date_created_gte;
-    private final Long date_created_lte;
 
     public ProductInput(List<String> productIdList) {
-        this.display_status = null;
-        this.product_type = null;
-        this.entry_type = null;
-        this.suspend_status = null;
-        this.quality_status = null;
-        this.skip_count = 0L;
-        this.limit_count = 50L;
-        this.product_code_list = null;
-        this.name = null;
         this.id_list = productIdList;
-        this.external_product_ids = null;
-        this.brand_id_list = null;
-        this.preorder = null;
-        this.trait_type_list = null;
-        this.penalty_status_list = null;
-        this.sales_status_list = Arrays.asList("ON_SALE");
-        this.date_created_gte = 946652400000L;
-        this.date_created_lte = 1687618799999L;
     }
 }

--- a/src/main/java/nunu/orderCount/infra/zigzag/service/ZigzagProductService.java
+++ b/src/main/java/nunu/orderCount/infra/zigzag/service/ZigzagProductService.java
@@ -32,6 +32,7 @@ public class ZigzagProductService extends ZigzagWebClientRequester{
     }
 
     public String ZigzagProductImageUrlRequester(String cookie, String productId){
+//        long endTime = System.currentTimeMillis();
         RequestZigzagProductInfoDto requestZigzagProductInfoDto = new RequestZigzagProductInfoDto(query, Arrays.asList(productId));
         String responseJson = post(PRODUCT_REQUEST_URI, cookie, requestZigzagProductInfoDto, String.class);
         return parseProductInfo(responseJson);
@@ -43,7 +44,11 @@ public class ZigzagProductService extends ZigzagWebClientRequester{
      * @return productId, imageUrl
      */
     public Map<String, String> ZigzagProductImagesUrlRequester(String cookie, List<String> productIdList){
+
+        long endTime = System.currentTimeMillis();
         RequestZigzagProductInfoDto requestZigzagProductInfoDto = new RequestZigzagProductInfoDto(query, productIdList);
+        String.join(",", productIdList);
+
         String responseJson = post(PRODUCT_REQUEST_URI, cookie, requestZigzagProductInfoDto, String.class);
         return parseProductInfoList(responseJson);
     }
@@ -85,9 +90,8 @@ public class ZigzagProductService extends ZigzagWebClientRequester{
 
             JSONObject jsonObj = (JSONObject) parser.parse(json);
             JSONObject data = (JSONObject) jsonObj.get("data");
-            JSONObject catalogProductList = (JSONObject) data.get("catalog_product_list");
-            long totalCount = (long) catalogProductList.get("total_count");
-            JSONArray productList = (JSONArray) catalogProductList.get("product_list");
+            JSONObject cachedProductList = (JSONObject) data.get("cached_product_list");
+            JSONArray productList = (JSONArray) cachedProductList.get("product_list");
 
             for(int i=0;i<productList.size();i++){
                 JSONObject productInfo = (JSONObject) productList.get(i);

--- a/src/main/java/nunu/orderCount/infra/zigzag/service/ZigzagWebClientRequester.java
+++ b/src/main/java/nunu/orderCount/infra/zigzag/service/ZigzagWebClientRequester.java
@@ -32,7 +32,7 @@ public class ZigzagWebClientRequester {
                 .bodyToMono(responseDtoClass)
                 .block();
     }
-
+    
     protected <T> ClientResponse.Headers postGetHeader(String url, T requestDto) {
         ClientResponse clientResponse = webClient.post()
                 .uri(url)

--- a/src/test/java/nunu/orderCount/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/nunu/orderCount/domain/member/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import nunu.orderCount.domain.member.exception.LoginFailException;
 import nunu.orderCount.domain.member.exception.NotExistMemberException;
 import nunu.orderCount.domain.member.exception.ZigzagLoginFailException;
 import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.model.MemberInfo;
 import nunu.orderCount.domain.member.model.Role;
 import nunu.orderCount.domain.member.model.dto.request.RequestJoinDto;
 import nunu.orderCount.domain.member.model.dto.request.RequestLoginDto;
@@ -16,6 +17,7 @@ import nunu.orderCount.domain.member.model.dto.response.ResponseLoginDto;
 import nunu.orderCount.domain.member.model.dto.response.ResponseRefreshZigzagToken;
 import nunu.orderCount.domain.member.model.dto.response.ResponseReissueDto;
 import nunu.orderCount.domain.member.repository.MemberRepository;
+import nunu.orderCount.global.config.RedisTestContainers;
 import nunu.orderCount.global.config.jwt.JwtProvider;
 import nunu.orderCount.global.config.jwt.JwtToken;
 import nunu.orderCount.global.util.RedisUtil;
@@ -41,7 +43,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @Slf4j
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, RedisTestContainers.class})
 class MemberServiceTest {
 
     @Mock
@@ -280,6 +282,20 @@ class MemberServiceTest {
         }
     }
 
+    @Test
+    @DisplayName("회원 정보 생성")
+    void createMemberInfo(){
+        //given
+        Member testMember = createTestMember(email, password, 1L);
+
+        doReturn(Optional.of(testMember)).when(memberRepository).findById(anyLong());
+        doReturn("update" + zigzagToken).when(redisUtil).getData(anyString());
+
+        MemberInfo memberInfo = memberService.createMemberInfo(1L);
+
+        assertThat(memberInfo.getMember().getMemberId()).isEqualTo(1L);
+    }
+
     private Member createTestMember(String email, String password, Long memberId){
         Member testMember = Member.builder()
                 .email(email)
@@ -294,6 +310,5 @@ class MemberServiceTest {
         );
         return testMember;
     }
-
 
 }

--- a/src/test/java/nunu/orderCount/domain/option/repository/OptionRepositoryTest.java
+++ b/src/test/java/nunu/orderCount/domain/option/repository/OptionRepositoryTest.java
@@ -1,0 +1,73 @@
+package nunu.orderCount.domain.option.repository;
+
+import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.repository.MemberRepository;
+import nunu.orderCount.domain.option.model.Option;
+import nunu.orderCount.domain.product.model.Product;
+import nunu.orderCount.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class OptionRepositoryTest {
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private OptionRepository optionRepository;
+
+    @Test
+    void findByProductAndName() {
+
+    }
+
+    @Test
+    @DisplayName("product, name 가진 option 존재하는지 찾기")
+    void existsByProductAndName() {
+        Member testMember = createTestMember("email", "password");
+        memberRepository.save(testMember);
+        Product p1 = productRepository.save(createTestProduct("p1", "1", testMember));
+        Product p2 = productRepository.save(createTestProduct("p2", "2", testMember));
+
+        optionRepository.save(createTestOption(p1, "option1"));
+        optionRepository.save(createTestOption(p2, "option2"));
+
+        assertThat(optionRepository.existsByProductAndName(p1, "option1")).isTrue();
+        assertThat(optionRepository.existsByProductAndName(p2, "option2")).isTrue();
+        assertThat(optionRepository.existsByProductAndName(p1, "option2")).isFalse();
+        assertThat(optionRepository.existsByProductAndName(p1, "option3")).isFalse();
+
+    }
+
+    private Option createTestOption(Product product, String name) {
+        return Option.builder()
+                .inventoryQuantity(0)
+                .product(product)
+                .name(name)
+                .build();
+    }
+
+    private Product createTestProduct(String name, String zigzagProductId, Member member){
+        return Product.builder()
+                .name(name)
+                .zigzagProductId(zigzagProductId)
+                .imageUrl("url")
+                .member(member)
+                .build();
+    }
+
+    private Member createTestMember(String email, String password){
+        Member testMember = Member.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        return testMember;
+    }
+}

--- a/src/test/java/nunu/orderCount/domain/option/service/OptionServiceTest.java
+++ b/src/test/java/nunu/orderCount/domain/option/service/OptionServiceTest.java
@@ -1,0 +1,82 @@
+package nunu.orderCount.domain.option.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.option.model.OptionDtoInfo;
+import nunu.orderCount.domain.option.model.dto.request.RequestCreateOptionsDto;
+import nunu.orderCount.domain.option.repository.OptionRepository;
+import nunu.orderCount.domain.product.model.Product;
+import nunu.orderCount.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OptionServiceTest {
+
+    @Mock
+    OptionRepository optionRepository;
+
+    @Mock
+    ProductRepository productRepository;
+
+    @InjectMocks
+    OptionService optionService;
+
+    @Test
+    @DisplayName("create options")
+    void createOptionsSuccess(){
+        //1. dto 받기 - MemberInfo, OptionDtoInfos
+        MemberInfo memberInfo = createMemberInfo();
+        List<OptionDtoInfo> optionDtoInfos = createOptionDtoInfos(1, 5);
+        RequestCreateOptionsDto requestCreateOptionsDto = new RequestCreateOptionsDto(createMemberInfo(),
+                optionDtoInfos);
+        Product product = createProduct("1", memberInfo.getMember(), "product");
+
+        //2. 이미 저장되어 있는 option 제거하기
+        doReturn(Optional.of(product)).when(productRepository)
+                .findByZigzagProductIdAndMember(anyString(), any(Member.class));
+        doReturn(true).when(optionRepository).existsByProductAndName(any(Product.class), anyString());
+        doReturn(List.of("1")).when(optionRepository).saveAll(anyList());
+
+        optionService.createOptions(requestCreateOptionsDto);
+    }
+
+    private MemberInfo createMemberInfo(){
+        return new MemberInfo(new Member("email", "password"), "token");
+    }
+
+    private List<OptionDtoInfo> createOptionDtoInfos(int start, int n){
+        new OptionDtoInfo("option1", "1");
+
+        List<OptionDtoInfo> optionDtoInfos = new ArrayList<>();
+        String num = "";
+        for(int i=start;i<start+n;i++){
+            num+=i;
+            optionDtoInfos.add(new OptionDtoInfo("option" + i, num));
+        }
+
+        return optionDtoInfos;
+    }
+
+    private Product createProduct(String zigzagProductId, Member member, String productName) {
+        return Product.builder()
+                .name(productName)
+                .imageUrl("")
+                .zigzagProductId(zigzagProductId)
+                .member(member)
+                .build();
+    }
+
+}

--- a/src/test/java/nunu/orderCount/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/nunu/orderCount/domain/order/controller/OrderControllerTest.java
@@ -1,0 +1,63 @@
+package nunu.orderCount.domain.order.controller;
+
+import nunu.orderCount.domain.order.model.dto.request.RequestOrderUpdateDto;
+import nunu.orderCount.domain.order.model.dto.response.ResponseOrderUpdateDto;
+import nunu.orderCount.domain.order.service.OrderServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Mock
+    private OrderServiceImpl orderService;
+
+    @InjectMocks
+    private OrderController orderController;
+
+    @Value("zigzag.id")
+    private String zigzagId;
+
+    @Value("zigzag.password")
+    private String zigzagPassword;
+
+
+    private final String BASE_URL = "/api/orders";
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @DisplayName("주문 업데이트")
+    @Test
+    void updateZigzagOrder() throws Exception {
+        //given
+//        doReturn(new ResponseOrderUpdateDto(1, 1)).when(orderService).orderUpdate(new RequestOrderUpdateDto(anyLong()));
+        //when
+
+
+        //then
+//        mvc.perform(post(BASE_URL + "/" + 1L))
+//                .andExpect(status().isOk());
+
+
+    }
+}

--- a/src/test/java/nunu/orderCount/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/nunu/orderCount/domain/order/repository/OrderRepositoryTest.java
@@ -74,6 +74,20 @@ class OrderRepositoryTest {
         //then
         assertThat(latestOrder.get().getMember()).isEqualTo(testMember);
     }
+
+    @DisplayName("주문 없을 때 최근 주문 조회")
+    @Test
+    void findTopByMemberOrderByDatePaidDescWhenNotOrderTest(){
+        //given
+        Member testMember = createTestMember("email", "password");
+        memberRepository.save(testMember);
+        //when
+        Optional<Order> latestOrder = orderRepository.findTopByMemberOrderByDatePaidDesc(testMember);
+
+        //then
+        assertThat(latestOrder).isEqualTo(Optional.empty());
+    }
+
     private Member createTestMember(String email, String password){
         Member testMember = Member.builder()
                 .email(email)

--- a/src/test/java/nunu/orderCount/domain/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/nunu/orderCount/domain/product/repository/ProductRepositoryTest.java
@@ -64,6 +64,45 @@ class ProductRepositoryTest {
         assertThat(product.get().getZigzagProductId()).isEqualTo("zigzagProductId");
 
     }
+
+    @DisplayName("zigzag 상품 id, member 로 상품 존재 확인")
+    @Test
+    void findByZigzagProductIdAndMember() {
+        //given
+        Member testMember = createTestMember("email", "password");
+        memberRepository.save(testMember);
+        Product testProduct = Product.builder()
+                .imageUrl("url")
+                .name("name")
+                .zigzagProductId("zigzagProductId")
+                .member(testMember)
+                .build();
+        productRepository.save(testProduct);
+        Product product = productRepository.findByZigzagProductIdAndMember("zigzagProductId", testMember).get();
+
+        //when, then
+        assertThat(product.getZigzagProductId()).isEqualTo("zigzagProductId");
+    }
+
+    @DisplayName("zigzag 상품 번호, member 로 조회")
+    @Test
+    void existsByZigzagProductIdAndMember() {
+        //given
+        Member testMember = createTestMember("email", "password");
+        memberRepository.save(testMember);
+        Product testProduct = Product.builder()
+                .imageUrl("url")
+                .name("name")
+                .zigzagProductId("zigzagProductId")
+                .member(testMember)
+                .build();
+        productRepository.save(testProduct);
+
+        //when, then
+        assertThat(productRepository.existsByZigzagProductIdAndMember("zigzagProductId", testMember)).isTrue();
+        assertThat(productRepository.existsByZigzagProductIdAndMember("productId", testMember)).isFalse();
+    }
+
     private Member createTestMember(String email, String password){
         Member testMember = Member.builder()
                 .email(email)

--- a/src/test/java/nunu/orderCount/domain/product/service/ProductServiceImplTest.java
+++ b/src/test/java/nunu/orderCount/domain/product/service/ProductServiceImplTest.java
@@ -1,0 +1,63 @@
+package nunu.orderCount.domain.product.service;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import nunu.orderCount.domain.member.model.Member;
+import nunu.orderCount.domain.member.model.MemberInfo;
+import nunu.orderCount.domain.product.model.ProductDtoInfo;
+import nunu.orderCount.domain.product.model.dto.request.RequestUpdateProductDto;
+import nunu.orderCount.domain.product.repository.ProductRepository;
+import nunu.orderCount.infra.zigzag.service.ZigzagProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceImplTest {
+
+    @Mock
+    ProductRepository productRepository;
+
+    @Mock
+    ZigzagProductService zigzagProductService;
+
+    @InjectMocks
+    ProductServiceImpl productService;
+
+    @Test
+    @DisplayName("모든 데이터 새로 저장하는 경우")
+    void updateProduct() {
+        RequestUpdateProductDto requestUpdateProductDto = makeUpdateProductDto();
+        doReturn(false).when(productRepository).existsByZigzagProductId(anyString());
+        doReturn(Map.of("product1", "url1", "product2", "url2")).when(zigzagProductService)
+                .ZigzagProductImagesUrlRequester(anyString(), anyList());
+        doReturn(List.of("1")).when(productRepository).saveAll(anyList());
+
+        productService.updateProduct(requestUpdateProductDto);
+    }
+
+    private RequestUpdateProductDto makeUpdateProductDto(){
+        return new RequestUpdateProductDto(new MemberInfo(new Member("email", "password"), "token"),
+                makeProductDtoInfos(0, 3));
+    }
+
+    private List<ProductDtoInfo> makeProductDtoInfos(int start, int n){
+        new ProductDtoInfo("청바지", "11111");
+        String name = "";
+        String productId = "";
+        List<ProductDtoInfo> productDtoInfos = new ArrayList<>();
+        for(int i=start;i<start+n;i++){
+            productId += i;
+            productDtoInfos.add(new ProductDtoInfo(name + i, productId));
+        }
+        return productDtoInfos;
+    }
+}

--- a/src/test/java/nunu/orderCount/infra/zigzag/service/ZigzagOrderServiceTest.java
+++ b/src/test/java/nunu/orderCount/infra/zigzag/service/ZigzagOrderServiceTest.java
@@ -1,0 +1,34 @@
+package nunu.orderCount.infra.zigzag.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import nunu.orderCount.infra.zigzag.model.dto.response.ResponseZigzagOrderDto;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+class ZigzagOrderServiceTest {
+
+    @Autowired
+    ZigzagOrderService zigzagOrderService;
+
+    @Value("${webclient.zigzag.cookie}")
+    String cookie;
+
+    @Test
+    void zigzagOrderListRequester() {
+        List<ResponseZigzagOrderDto> responseZigzagOrders = zigzagOrderService.zigzagOrderListRequester(cookie,
+                20231220, 20231222);
+
+        assertThat(responseZigzagOrders.size()).isGreaterThan(0);
+    }
+    
+    //todo: zigzag error 상황 test 필요
+}

--- a/src/test/java/nunu/orderCount/infra/zigzag/service/ZigzagProductServiceTest.java
+++ b/src/test/java/nunu/orderCount/infra/zigzag/service/ZigzagProductServiceTest.java
@@ -1,0 +1,33 @@
+package nunu.orderCount.infra.zigzag.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+class ZigzagProductServiceTest {
+
+    @Autowired
+    ZigzagProductService zigzagProductService;
+
+    @Value("${webclient.zigzag.cookie}")
+    String cookie;
+
+    @Test
+    void zigzagProductImagesUrlRequester() {
+        Map<String, String> stringStringMap = zigzagProductService.ZigzagProductImagesUrlRequester(cookie,
+                List.of("130385013"));
+        assertThat(stringStringMap.size()).isEqualTo(1L);
+    }
+    
+    //todo: 안되는 경우 test 필요
+}


### PR DESCRIPTION
## 주문 업데이트 기능 구현

1. MemberInfo
    - member와 zigzagToken으로 구성되어 있다.
    - memberService에서 createMemberInfo로 만들 수 있다.
2. OrderService
    1. getOrdersFromZigzag
        - zigzagOrderService의 zigzagOrderListRequester로 주문 정보를 받아온다.
        - 가장 최근 저장된 주문 이후 건부터 받아온다. (없으면 처음부터)
    2. orderUpdate
        - 배송준비중인 order list를 만든다.
        - orderRepository에 저장되어 있지 않은 order list를 만든다.
        - 완료된 order 상태를 변환하고 새로운 order를 저장한다.
3. ProductService
    - 저장되지 않은 product들을 stream을 이용해 찾는다.
    - zigzagProductService의 ZigzagProductImagesUrlRequester를 이용해 productId로 image url을 가져온다.
    - product list를 만들어 saveAll한다.
4. OptionService
    - 저장되지 않은 option을 추출한 후 saveAll한다.

## 주문 업데이트 API - OrderController
- updateZigzagOrder
    1. memberInfo를 만든다.
    2. orderService를 이용해 주문 정보를 받아온다.
    2. product와 option, order를 update한다.